### PR TITLE
fix bug with old version laravel

### DIFF
--- a/src/TelegramServiceProvider.php
+++ b/src/TelegramServiceProvider.php
@@ -21,4 +21,11 @@ class TelegramServiceProvider extends ServiceProvider
                 );
             });
     }
+
+    /**
+     * Register any package services.
+     */
+    public function register()
+    {
+    }
 }


### PR DESCRIPTION
Bugfix with Laravel 5.1:
```sh
[Symfony\Component\Debug\Exception\FatalErrorException]                                                                                                                                                           
  Class NotificationChannels\Telegram\TelegramServiceProvider contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Illuminate\Support\ServiceProvider::register) 
```