### PR TITLE
Add ability to change button columns

### DIFF
--- a/src/TelegramMessage.php
+++ b/src/TelegramMessage.php
@@ -71,11 +71,11 @@ class TelegramMessage
      *
      * @return $this
      */
-    public function button($text, $url)
+    public function button($text, $url, $columns = 2)
     {
         $this->buttons[] = compact('text', 'url');
 
-        $replyMarkup['inline_keyboard'] = array_chunk($this->buttons, 2);
+        $replyMarkup['inline_keyboard'] = array_chunk($this->buttons, $columns);
         $this->payload['reply_markup'] = json_encode($replyMarkup);
 
         return $this;


### PR DESCRIPTION
Telegram API has ability to pass keyboard as array, this plugin was splitting array as 2 element chunks. Now button() function accepts third parameter $columns (default is 2), which is the number of elements in single array.