### PR TITLE
Add Photo, Document, Audio, Sticker support + Additional error details in Exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,50 @@ Here's a screenshot preview of the above notification on Telegram Messenger:
 
 ![Laravel Telegram Notification Example](https://cloud.githubusercontent.com/assets/1915268/17590374/2e05e872-5ff7-11e6-992f-63d5f3df2db3.png)
 
+### Attach a Photo
+
+``` php
+...
+    public function toTelegram($notifiable)
+    {
+        $url = url('/file/' . $this->file->id);
+
+        return TelegramMessage::create()
+            ->to($this->user->telegram_user_id) // Optional.
+            ->content("*bold text* [inline URL](http://www.example.com/)") // Markdown supported.
+            ->file('/storage/archive/6029014.jpg', 'photo') // local photo
+            // OR
+            // ->file('https://pisces.bbystatic.com/image2/BestBuy_US/images/products/6029/6029014_rd.jpg', 'photo') // remote photo
+            ->button('Download PDF', $url); // Inline Button
+    }
+...
+```
+Sample :
+![photo5879686121305255739](https://user-images.githubusercontent.com/785830/46316802-ff82b300-c5dd-11e8-85c9-58c66ad29895.jpg)
+
+
+### Attach a Document
+
+``` php
+...
+    public function toTelegram($notifiable)
+    {
+        $url = url('/file/' . $this->file->id);
+
+        return TelegramMessage::create()
+            ->to($this->user->telegram_user_id) // Optional.
+            ->content("*bold text* [inline URL](http://www.example.com/)") // Markdown supported.
+            ->file('/storage/archive/file.pdf', 'document') // local file
+            // OR
+            // ->file('http://www.domain.com/file.pdf', 'document') // remote file
+            ->button('Download PDF', $url); // Inline Button
+    }
+...
+```
+Sample :
+![photo5879686121305255737](https://user-images.githubusercontent.com/785830/46316801-feea1c80-c5dd-11e8-99c2-21d00b165a66.jpg)
+
+
 ### Routing a message
 
 You can either send the notification by providing with the chat id of the recipient to the `to($chatId)` method like shown in the above example or add a `routeNotificationForTelegram()` method in your notifiable model:

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -43,9 +43,9 @@ class CouldNotSendNotification extends \Exception
      *
      * @return static
      */
-    public static function couldNotCommunicateWithTelegram()
+     public static function couldNotCommunicateWithTelegram($message)
     {
-        return new static('The communication with Telegram failed.');
+        return new static("The communication with Telegram failed. `{$message}`");
     }
 
     /**

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -92,14 +92,16 @@ class Telegram
      *
      * @param $endpoint
      * @param $params
+     * @param bool $multipart
      *
      * @throws CouldNotSendNotification
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
-    protected function sendRequest($endpoint, $params)
+    protected function sendRequest($endpoint, $params, $multipart = false)
     {
-        if (empty($this->token)) {
+        if (empty($this->token))
+        {
             throw CouldNotSendNotification::telegramBotTokenNotProvided('You must provide your telegram bot token to make any API requests.');
         }
 

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -5,6 +5,7 @@ namespace NotificationChannels\Telegram;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\ClientException;
 use NotificationChannels\Telegram\Exceptions\CouldNotSendNotification;
+use GuzzleHttp\Post\PostFile;
 
 class Telegram
 {
@@ -69,6 +70,23 @@ class Telegram
         return $this->sendRequest('sendMessage', $params);
     }
 
+
+    /**
+    * Send File as Image or Document
+    *
+    * @param array $params
+    * @param string $type
+    * @param bool $multipart
+    * 
+    * @return mixed
+    * 
+    */
+    public function sendFile($params, $type, $multipart = false)
+    {
+        return $this->sendRequest('send'.ucfirst($type), $params, $multipart);
+    }
+
+
     /**
      * Send an API request and return response.
      *
@@ -88,13 +106,19 @@ class Telegram
         $endPointUrl = 'https://api.telegram.org/bot'.$this->token.'/'.$endpoint;
 
         try {
+            if($multipart)
+                $post_name = 'multipart';
+            else
+                $post_name = 'form_params';
+
             return $this->httpClient()->post($endPointUrl, [
-                'form_params' => $params,
+                $post_name => $params,
             ]);
+
         } catch (ClientException $exception) {
             throw CouldNotSendNotification::telegramRespondedWithAnError($exception);
         } catch (\Exception $exception) {
-            throw CouldNotSendNotification::couldNotCommunicateWithTelegram();
+            throw CouldNotSendNotification::couldNotCommunicateWithTelegram($exception);
         }
     }
 }

--- a/src/TelegramChannel.php
+++ b/src/TelegramChannel.php
@@ -44,8 +44,23 @@ class TelegramChannel
             $message->to($to);
         }
 
-        $params = $message->toArray();
-
-        $this->telegram->sendMessage($params);
+        if(isset($message->payload['text']) && $message->payload['text'])
+        {
+            $params = $message->toArray();
+            $this->telegram->sendMessage($params);
+        }
+        else
+        {
+            if(isset($message->payload['file']))
+            {
+                $params = $message->toMultipart();
+                $this->telegram->sendFile($params, $message->type, true);
+            }
+            else
+            {
+                $params = $message->toArray();
+                $this->telegram->sendFile($params, $message->type);
+            }
+        }
     }
 }

--- a/src/TelegramFile.php
+++ b/src/TelegramFile.php
@@ -2,8 +2,13 @@
 
 namespace NotificationChannels\Telegram;
 
-class TelegramMessage
+class TelegramFile
 {
+    /**
+     * @var string content type.
+     */
+    public $type = 'document';
+
     /**
      * @var array Params payload.
      */
@@ -25,7 +30,7 @@ class TelegramMessage
     }
 
     /**
-     * Message constructor.
+     * Document constructor.
      *
      * @param string $content
      */
@@ -58,7 +63,34 @@ class TelegramMessage
      */
     public function content($content)
     {
-        $this->payload['text'] = $content;
+        $this->payload['caption'] = $content;
+
+        return $this;
+    }
+
+
+    /**
+    * add File to Message
+    *
+    * @param string $file
+    * @param string $type
+    * @param string $filename
+    *
+    * @return $this
+    *
+    */
+    public function file($file, $type, $filename = null)
+    {
+        $this->type = $type;
+
+        if(is_file($file))
+        {
+            $this->payload['file'] = ['name' => $type, 'contents'=> fopen($file, 'r')];
+            if($filename)
+                $this->payload['file']['filename'] = $filename;
+        }
+        else
+            $this->payload[$type] = $file;
 
         return $this;
     }
@@ -83,7 +115,7 @@ class TelegramMessage
     }
 
     /**
-     * Additional options to pass to sendMessage method.
+     * Additional options to pass to sendDocument method.
      *
      * @param array $options
      *
@@ -114,5 +146,28 @@ class TelegramMessage
     public function toArray()
     {
         return $this->payload;
+    }
+
+
+    /**
+    * Create Multipart array
+    *
+    * @return array
+    *
+    */
+    public function toMultipart()
+    {
+        $data = [];
+        foreach ($this->payload as $key => $value) {
+            if($key!='file')
+            {
+                $data[] = ['name' => $key, 'contents' => $value];
+            }
+            else
+            {
+                $data[] = $value;
+            }
+        }
+        return $data;
     }
 }


### PR DESCRIPTION
Hi,

I Add functionality to send other file types.

* As details in README you can input file type in second parameter of **file()** method, it will be convert to Telegram API endpoint url.
for example *'photo' => 'sendPhoto'* OR *'document' => 'sendDocument'* etc, base on [Telegram API documentation](https://core.telegram.org/bots/api#senddocument).
* local and remote file accepted.
* I tested it for photos and documents but it should work with Audio and Sticker too because same minimum required parameters.

Best Regards
Iraj Taghlidi