### PR TITLE
Added Location support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 build
 composer.phar
 composer.lock
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build
 composer.phar
 composer.lock
+.idea/

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -86,6 +86,19 @@ class Telegram
         return $this->sendRequest('send'.ucfirst($type), $params, $multipart);
     }
 
+    /**
+     * Send a Location
+     *
+     * @param array $params
+     * @return mixed
+     *
+     * @throws CouldNotSendNotification
+     */
+    public function sendLocation($params)
+    {
+        return $this->sendRequest('sendLocation', $params);
+    }
+
 
     /**
      * Send an API request and return response.

--- a/src/TelegramChannel.php
+++ b/src/TelegramChannel.php
@@ -49,6 +49,10 @@ class TelegramChannel
             $params = $message->toArray();
             $this->telegram->sendMessage($params);
         }
+        elseif (isset($message->payload['latitude']) && isset($message->payload['longitude'])) {
+            $params = $message->toArray();
+            $this->telegram->sendLocation($params);
+        }
         else
         {
             if(isset($message->payload['file']))

--- a/src/TelegramLocation.php
+++ b/src/TelegramLocation.php
@@ -30,8 +30,6 @@ class TelegramLocation
     {
         $this->latitude($latitude);
         $this->longitude($longitude);
-
-        $this->payload['parse_mode'] = 'Markdown';
     }
 
     /**

--- a/src/TelegramLocation.php
+++ b/src/TelegramLocation.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace NotificationChannels\Telegram;
+
+class TelegramLocation
+{
+    /**
+     * @var array Params payload.
+     */
+    public $payload = [];
+
+    /**
+     * @param null $latitude
+     * @param null $longitude
+     *
+     * @return static
+     */
+    public static function create($latitude = null, $longitude = null)
+    {
+        return new static($latitude, $longitude);
+    }
+
+    /**
+     * Message constructor.
+     *
+     * @param null $latitude
+     * @param null $longitude
+     */
+    public function __construct($latitude = null, $longitude = null)
+    {
+        $this->latitude($latitude);
+        $this->longitude($longitude);
+
+        $this->payload['parse_mode'] = 'Markdown';
+    }
+
+    /**
+     * Recipient's Chat ID.
+     *
+     * @param $chatId
+     *
+     * @return $this
+     */
+    public function to($chatId)
+    {
+        $this->payload['chat_id'] = $chatId;
+
+        return $this;
+    }
+
+    /**
+     * Location's latitude.
+     *
+     * @param $latitude
+     *
+     * @return TelegramLocation
+     */
+    public function latitude($latitude)
+    {
+        $this->payload['latitude'] = $latitude;
+
+        return $this;
+    }
+
+    /**
+     * Location's latitude.
+     *
+     * @param $longitude
+     *
+     * @return TelegramLocation
+     */
+    public function longitude($longitude)
+    {
+        $this->payload['longitude'] = $longitude;
+
+        return $this;
+    }
+
+    /**
+     * Additional options to pass to sendLocation method.
+     *
+     * @param array $options
+     *
+     * @return $this
+     */
+    public function options(array $options)
+    {
+        $this->payload = array_merge($this->payload, $options);
+
+        return $this;
+    }
+
+    /**
+     * Determine if chat id is not given.
+     *
+     * @return bool
+     */
+    public function toNotGiven()
+    {
+        return !isset($this->payload['chat_id']);
+    }
+
+    /**
+     * Returns params payload.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->payload;
+    }
+}

--- a/tests/TelegramLocationTest.php
+++ b/tests/TelegramLocationTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace NotificationChannels\Telegram\Test;
+
+use NotificationChannels\Telegram\TelegramLocation;
+
+class TelegramLocationTest extends \PHPUnit_Framework_TestCase
+{
+    const TEST_LONG = -77.0364;
+    const TEST_LAT = 38.8951;
+
+    /** @test */
+    public function it_accepts_content_when_constructed()
+    {
+        $message = new TelegramLocation(self::TEST_LAT, self::TEST_LONG);
+        $this->assertEquals(self::TEST_LAT, $message->payload['latitude']);
+        $this->assertEquals(self::TEST_LONG, $message->payload['longitude']);
+    }
+
+    /** @test */
+    public function the_recipients_chat_id_can_be_set()
+    {
+        $message = new TelegramLocation();
+        $message->to(12345);
+        $this->assertEquals(12345, $message->payload['chat_id']);
+    }
+
+    /** @test */
+    public function the_notification_longitude_can_be_set()
+    {
+        $message = new TelegramLocation();
+        $message->longitude(self::TEST_LONG);
+        $this->assertEquals(self::TEST_LONG, $message->payload['longitude']);
+    }
+
+    /** @test */
+    public function the_notification_latitude_can_be_set()
+    {
+        $message = new TelegramLocation();
+        $message->latitude(self::TEST_LAT);
+        $this->assertEquals(self::TEST_LAT, $message->payload['latitude']);
+    }
+
+    /** @test */
+    public function additional_options_can_be_set_for_the_message()
+    {
+        $message = new TelegramLocation();
+        $message->options(['foo' => 'bar']);
+        $this->assertEquals('bar', $message->payload['foo']);
+    }
+
+    /** @test */
+    public function it_can_determine_if_the_recipient_chat_id_has_not_been_set()
+    {
+        $message = new TelegramLocation();
+        $this->assertTrue($message->toNotGiven());
+
+        $message->to(12345);
+        $this->assertFalse($message->toNotGiven());
+    }
+
+        /** @test */
+    public function it_can_return_the_payload_as_an_array()
+    {
+        $message = new TelegramLocation(self::TEST_LAT, self::TEST_LONG);
+        $message->to(12345);
+        $message->options(['foo' => 'bar']);
+        $expected = [
+            "chat_id" => 12345,
+            "foo" => "bar",
+            "longitude" => self::TEST_LONG,
+            "latitude" => self::TEST_LAT
+        ];
+
+        $this->assertEquals($expected, $message->toArray());
+    }
+}


### PR DESCRIPTION
Hi there!

Today I was looking around this project and needed to use it to also send locations in some of my notifications, so I added all the methods and a new `TelegramLocation` class.

I also added some tests for the new class.

## Usage
Like in others methods, the usage is similar:

``` php
use NotificationChannels\Telegram\TelegramChannel;
use NotificationChannels\Telegram\TelegramLocation;
use Illuminate\Notifications\Notification;

class SendLocation extends Notification
{
    public function via($notifiable)
    {
        return [TelegramChannel::class];
    }

    public function toTelegram($notifiable)
    {
        return TelegramLocation::create()
            ->to($this->user->telegram_user_id)
            ->latitude(38.8951)
            ->longitude(-77.0364);
    }
}
```
