### PR TITLE
Dropping requirement for PHP 7.2 in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         }
     ],
     "require": {
-        "php": "^7.2",
         "guzzlehttp/guzzle": "^6.2",
         "illuminate/notifications": "^5.5 || ^6.0",
         "illuminate/support": "^5.5 || ^6.0"


### PR DESCRIPTION
Fixes #58. Laravel requirements should be enough to infer PHP 7.2 requirements if needed.

