### PR TITLE
Allow to handle response from Telegram

### DIFF
--- a/src/TelegramChannel.php
+++ b/src/TelegramChannel.php
@@ -59,6 +59,8 @@ class TelegramChannel
             $response = $this->telegram->sendLocation($params);
         } elseif ($message instanceof TelegramFile) {
             $response = $this->telegram->sendFile($params, $message->type, $message->hasFile());
+        } else {
+            return null;
         }
 
         return json_decode($response->getBody()->getContents(), true);

--- a/src/TelegramChannel.php
+++ b/src/TelegramChannel.php
@@ -31,9 +31,11 @@ class TelegramChannel
      * @param mixed        $notifiable
      * @param Notification $notification
      *
+     * @return null|array
+     *
      * @throws CouldNotSendNotification
      */
-    public function send($notifiable, Notification $notification): void
+    public function send($notifiable, Notification $notification): ?array
     {
         $message = $notification->toTelegram($notifiable);
 
@@ -52,11 +54,13 @@ class TelegramChannel
         $params = $message->toArray();
 
         if ($message instanceof TelegramMessage) {
-            $this->telegram->sendMessage($params);
+            $response = $this->telegram->sendMessage($params);
         } elseif ($message instanceof TelegramLocation) {
-            $this->telegram->sendLocation($params);
+            $response = $this->telegram->sendLocation($params);
         } elseif ($message instanceof TelegramFile) {
-            $this->telegram->sendFile($params, $message->type, $message->hasFile());
+            $response = $this->telegram->sendFile($params, $message->type, $message->hasFile());
         }
+
+        return json_decode($response->getBody()->getContents());
     }
 }

--- a/src/TelegramChannel.php
+++ b/src/TelegramChannel.php
@@ -61,6 +61,6 @@ class TelegramChannel
             $response = $this->telegram->sendFile($params, $message->type, $message->hasFile());
         }
 
-        return json_decode($response->getBody()->getContents());
+        return json_decode($response->getBody()->getContents(), true);
     }
 }

--- a/tests/TelegramChannelTest.php
+++ b/tests/TelegramChannelTest.php
@@ -2,6 +2,7 @@
 
 namespace NotificationChannels\Telegram\Test;
 
+use GuzzleHttp\Psr7\Response;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use Mockery;
@@ -38,12 +39,18 @@ class ChannelTest extends TestCase
     /** @test */
     public function it_can_send_a_message(): void
     {
+        $expectedResponse = ['ok' => true, 'result' => ['message_id' => 123, 'chat' => ['id' => 12345]]];
+
         $this->telegram->shouldReceive('sendMessage')->once()->with([
-            'text'       => 'Laravel Notification Channels are awesome!',
+            'text' => 'Laravel Notification Channels are awesome!',
             'parse_mode' => 'Markdown',
-            'chat_id'    => 12345,
-        ]);
-        $this->channel->send(new TestNotifiable(), new TestNotification());
+            'chat_id' => 12345,
+        ])
+            ->andReturns(new Response(200, [], json_encode($expectedResponse)));
+
+        $actualResponse = $this->channel->send(new TestNotifiable(), new TestNotification());
+
+        self::assertSame($expectedResponse, $actualResponse);
     }
 
     /** @test */


### PR DESCRIPTION
This PR allows to handle response, received from [SendMessage](https://core.telegram.org/bots/api#sendmessage) method.

This response may be handled in [NotificationSent event](https://laravel.com/docs/5.8/notifications#notification-events).

When you have response for sent message you can then edit or delete sent notification as you'll have `message_id`.