### PR TITLE
add ability to set param in disableNotification

### DIFF
--- a/src/Traits/HasSharedLogic.php
+++ b/src/Traits/HasSharedLogic.php
@@ -51,11 +51,12 @@ trait HasSharedLogic
      * Send the message silently.
      * Users will receive a notification with no sound.
      *
+     * @param bool $disable_notification
      * @return $this
      */
-    public function disableNotification(): self
+    public function disableNotification(bool $disable_notification = true): self
     {
-        $this->payload['disable_notification'] = true;
+        $this->payload['disable_notification'] = $disable_notification;
 
         return $this;
     }

--- a/src/Traits/HasSharedLogic.php
+++ b/src/Traits/HasSharedLogic.php
@@ -51,12 +51,12 @@ trait HasSharedLogic
      * Send the message silently.
      * Users will receive a notification with no sound.
      *
-     * @param bool $disable_notification
+     * @param bool $disableNotification
      * @return $this
      */
-    public function disableNotification(bool $disable_notification = true): self
+    public function disableNotification(bool $disableNotification = true): self
     {
-        $this->payload['disable_notification'] = $disable_notification;
+        $this->payload['disable_notification'] = $disableNotification;
 
         return $this;
     }


### PR DESCRIPTION
this change gain ability to drop conditions like 
```
$message = TelegramMessage::create()
    ->to($notifiable->telegram_user_id);
$needSilent ?? $message->disableNotification();
return $message;
```
to
```
return TelegramMessage::create()
    ->to($notifiable->telegram_user_id)
    ->disableNotification($needSilent);
```