### PR TITLE
Include previous ClientException when constructing CouldNotSendNotifi…

### DIFF
--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -28,7 +28,7 @@ class CouldNotSendNotification extends Exception
         $result = json_decode($exception->getResponse()->getBody(), false);
         $description = $result->description ?? 'no description given';
 
-        return new static("Telegram responded with an error `{$statusCode} - {$description}`");
+        return new static("Telegram responded with an error `{$statusCode} - {$description}`", 0, $exception);
     }
 
     /**


### PR DESCRIPTION
…cation

This provides access to the API response body with $exception->getPrevious()->getResponse()->getBody() and fixes issue #85