### PR TITLE
Added 8.1 as experimental for tests, dropped 7.1

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 8.0
+                  php-version: 7.4
                   tools: composer:v2
                   coverage: pcov
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,11 +7,17 @@ on:
 jobs:
     tests:
         runs-on: ubuntu-latest
+        continue-on-error: ${{ matrix.experimental }}
         strategy:
             fail-fast: true
             matrix:
-                php: [7.1, 7.2, 7.3, 7.4, 8.0]
+                php: [7.2, 7.3, 7.4, 8.0]
                 stability: [prefer-lowest, prefer-stable]
+                experimental: [false]
+                include:
+                    - php: 8.1
+                      stability: prefer-stable
+                      experimental: true
 
         name: Tests on PHP ${{ matrix.php }} - ${{ matrix.stability }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `telegram` will be documented in this file
 
+## Unreleased
+- dropped PHP 7.1 support
+
 ## 0.6.0 - 2021-10-04
 
 - Add GitHub Actions workflows for tests and coverage. PR [#103](https://github.com/laravel-notification-channels/telegram/pull/103).

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.2 || ^7.0",
         "illuminate/notifications": "^5.5 || ^6.0 || ^7.0 || ^8.0",


### PR DESCRIPTION
1. Based on this page https://packagist.org/packages/laravel-notification-channels/telegram/php-stats, 7.1 is almost not used, so I think it can be dropped, so I've updated composer.json and tests workflow
2. Changed coverage workflow to run on 7.4, as scrutinizer ocular script cannot work on 8.0 for now