### PR TITLE
Dispatch event NotificationFailed if an exception has occurred

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.2 || ^7.0",
+        "illuminate/contracts": "^5.5 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/notifications": "^5.5 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0"
     },

--- a/src/TelegramChannel.php
+++ b/src/TelegramChannel.php
@@ -2,6 +2,8 @@
 
 namespace NotificationChannels\Telegram;
 
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Notification;
 use NotificationChannels\Telegram\Exceptions\CouldNotSendNotification;
 
@@ -16,13 +18,20 @@ class TelegramChannel
     protected $telegram;
 
     /**
+     * @var Dispatcher
+     */
+    private $dispatcher;
+
+    /**
      * Channel constructor.
      *
      * @param Telegram $telegram
+     * @param Dispatcher $dispatcher
      */
-    public function __construct(Telegram $telegram)
+    public function __construct(Telegram $telegram, Dispatcher $dispatcher)
     {
         $this->telegram = $telegram;
+        $this->dispatcher = $dispatcher;
     }
 
     /**
@@ -56,15 +65,27 @@ class TelegramChannel
 
         $params = $message->toArray();
 
-        if ($message instanceof TelegramMessage) {
-            $response = $this->telegram->sendMessage($params);
-        } elseif ($message instanceof TelegramLocation) {
-            $response = $this->telegram->sendLocation($params);
-        } elseif ($message instanceof TelegramFile) {
-            $response = $this->telegram->sendFile($params, $message->type, $message->hasFile());
-        } else {
-            return null;
+        try{
+            if ($message instanceof TelegramMessage) {
+                $response = $this->telegram->sendMessage($params);
+            } elseif ($message instanceof TelegramLocation) {
+                $response = $this->telegram->sendLocation($params);
+            } elseif ($message instanceof TelegramFile) {
+                $response = $this->telegram->sendFile($params, $message->type, $message->hasFile());
+            } else {
+                return null;
+            }
+        } catch (CouldNotSendNotification $exception) {
+            $this->dispatcher->dispatch(new NotificationFailed(
+                $notifiable,
+                $notification,
+                'telegram',
+                []
+            ));
+
+            throw $exception;
         }
+
 
         return json_decode($response->getBody()->getContents(), true);
     }

--- a/src/TelegramServiceProvider.php
+++ b/src/TelegramServiceProvider.php
@@ -3,6 +3,7 @@
 namespace NotificationChannels\Telegram;
 
 use GuzzleHttp\Client as HttpClient;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\ServiceProvider;
@@ -35,11 +36,14 @@ class TelegramServiceProvider extends ServiceProvider
     {
         Notification::resolved(function (ChannelManager $service) {
             $service->extend('telegram', function ($app) {
-                return new TelegramChannel(new Telegram(
-                    config('services.telegram-bot-api.token'),
-                    app(HttpClient::class),
-                    config('services.telegram-bot-api.base_uri')
-                ));
+                return new TelegramChannel(
+                    new Telegram(
+                        config('services.telegram-bot-api.token'),
+                        app(HttpClient::class),
+                        config('services.telegram-bot-api.base_uri')
+                    ),
+                    app(Dispatcher::class)
+                );
             });
         });
     }


### PR DESCRIPTION
Laravel has a NotificationFailed event, but it does not dispatch it, unlike the NotificationSent event. It would be convenient to dispatch an event if an error occurred while sending the message.