### PR TITLE
send notification to multiple receivers

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -186,7 +186,7 @@ class Telegram
 
         $apiUri = sprintf('%s/bot%s/%s', $this->apiBaseUri, $this->token, $endpoint);
 
-        foreach($restructureParams as $params){
+        foreach($restructureParams as $key => $params){
             try {
                 $response = $this->httpClient()->post($apiUri, [
                     $multipart ? 'multipart' : 'form_params' => $params,
@@ -195,6 +195,10 @@ class Telegram
                 throw CouldNotSendNotification::telegramRespondedWithAnError($exception);
             } catch (Exception $exception) {
                 throw CouldNotSendNotification::couldNotCommunicateWithTelegram($exception);
+            }
+
+            if($key !== array_key_last($restructureParams)){
+                sleep(1);
             }
         }
 

--- a/src/Traits/HasSharedLogic.php
+++ b/src/Traits/HasSharedLogic.php
@@ -19,13 +19,13 @@ trait HasSharedLogic
     /**
      * Recipient's Chat ID.
      *
-     * @param string|int $chatId
+     * @param array $chatId
      *
      * @return $this
      */
-    public function to($chatId): self
+    public function to(...$chatId): self
     {
-        $this->payload['chat_id'] = $chatId;
+        $this->payload['chat_id'] = func_num_args() > 1 ? $chatId : $chatId[0];
 
         return $this;
     }

--- a/tests/TelegramLocationTest.php
+++ b/tests/TelegramLocationTest.php
@@ -27,6 +27,9 @@ class TelegramLocationTest extends TestCase
         $message = new TelegramLocation();
         $message->to(12345);
         $this->assertEquals(12345, $message->getPayloadValue('chat_id'));
+
+        $message->to(12345, 54321);
+        $this->assertEquals([12345, 54321], $message->getPayloadValue('chat_id'));
     }
 
     /** @test */
@@ -61,6 +64,9 @@ class TelegramLocationTest extends TestCase
 
         $message->to(12345);
         $this->assertFalse($message->toNotGiven());
+
+        $message->to(12345, 54321);
+        $this->assertFalse($message->toNotGiven());
     }
 
     /** @test */
@@ -71,6 +77,16 @@ class TelegramLocationTest extends TestCase
         $message->options(['foo' => 'bar']);
         $expected = [
             'chat_id'   => 12345,
+            'foo'       => 'bar',
+            'longitude' => self::TEST_LONG,
+            'latitude'  => self::TEST_LAT,
+        ];
+
+        $this->assertEquals($expected, $message->toArray());
+
+        $message->to(12345, 54321);
+        $expected = [
+            'chat_id'   => [12345, 54321],
             'foo'       => 'bar',
             'longitude' => self::TEST_LONG,
             'latitude'  => self::TEST_LAT,

--- a/tests/TelegramMessageTest.php
+++ b/tests/TelegramMessageTest.php
@@ -30,6 +30,9 @@ class TelegramMessageTest extends TestCase
         $message = new TelegramMessage();
         $message->to(12345);
         $this->assertEquals(12345, $message->getPayloadValue('chat_id'));
+
+        $message->to(12345, 654321);
+        $this->assertEquals([12345, 654321], $message->getPayloadValue('chat_id'));
     }
 
     /** @test */
@@ -74,6 +77,9 @@ class TelegramMessageTest extends TestCase
 
         $message->to(12345);
         $this->assertFalse($message->toNotGiven());
+
+        $message->to(12345, 54321);
+        $this->assertFalse($message->toNotGiven());
     }
 
     /** @test */
@@ -87,6 +93,17 @@ class TelegramMessageTest extends TestCase
             'text'         => 'Laravel Notification Channels are awesome!',
             'parse_mode'   => 'Markdown',
             'chat_id'      => 12345,
+            'foo'          => 'bar',
+            'reply_markup' => '{"inline_keyboard":[[{"text":"Laravel","url":"https:\/\/laravel.com"}]]}',
+        ];
+
+        $this->assertEquals($expected, $message->toArray());
+
+        $message->to(12345, 54321);
+        $expected = [
+            'text'         => 'Laravel Notification Channels are awesome!',
+            'parse_mode'   => 'Markdown',
+            'chat_id'      => [12345, 54321],
             'foo'          => 'bar',
             'reply_markup' => '{"inline_keyboard":[[{"text":"Laravel","url":"https:\/\/laravel.com"}]]}',
         ];


### PR DESCRIPTION
Hello 👋🏻

I've made this PR so we can send notification to multiple receivers by separating chatIds by a comma in ```to()``` method

Examples:

```
TelegramMessage::create()
            ->to($receiver1, $receiver2)
            ->content("Hello there!");
```


```
TelegramFile::create()
        ->to($receiver1, $receiver2)
        ->content('Hello there!')
        ->file($photo, 'photo');
```


```
TelegramLocation::create()
        ->to($receiver1, $receiver2)
        ->latitude($latitude)
        ->longitude($longitude);
```