### PR TITLE
Fixed `PHP Deprecated:  Return type of NotificationChannels\Telegram\…

### DIFF
--- a/src/Traits/HasSharedLogic.php
+++ b/src/Traits/HasSharedLogic.php
@@ -141,9 +141,9 @@ trait HasSharedLogic
     /**
      * Convert the object into something JSON serializable.
      *
-     * @return mixed
+     * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }


### PR DESCRIPTION
…TelegramMessage::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed`

Tested with Laravel 9