### PR TITLE
Added HTML parse_mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ class InvoicePaid extends Notification
             // Markdown supported.
             ->content("Hello there!\nYour invoice has been *PAID*")
 
+            // If you need to send a simple text, without Markdown support
+            ->text("It's just text")
+            
+            // (Optional) Or you can call this method to set "parse_mode = HTML" and use any method.
+            ->htmlParseMode()
+            
             // (Optional) Blade template for the content.
             // ->view('notification', ['url' => $url])
 
@@ -378,6 +384,9 @@ For more information on supported parameters, check out these [docs](https://tel
 - `content(string $content, int $limit = null)`: Notification message, supports markdown. For more information on supported markdown styles, check out these [docs](https://telegram-bot-sdk.readme.io/reference#section-formatting-options).
 - `view(string $view, array $data = [], array $mergeData = [])`: (optional) Blade template name with Telegram supported HTML or Markdown syntax content if you wish to use a view file instead of the `content()` method.
 - `chunk(int $limit = 4096)`: (optional) Message chars chunk size to send in parts (For long messages). Note: Chunked messages will be rate limited to one message per second to comply with rate limitation requirements from Telegram.
+- `text(string $content, int $limit = null)`: Notification simple message without markdown.
+- `viewHtml(string $view, array $data = [], array $mergeData = [])`: (optional) Blade template name with Telegram supported only HTML syntax content if you wish to use a view file instead of the `content()` or `text()` methods.
+- `htmlParseMode()`: You can still use any of the methods - `content()`, `view()`, but if you need to install the `parse_mode = HTML`, just call this method.
 
 ### Telegram Location methods
 

--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -14,6 +14,16 @@ use Psr\Http\Message\ResponseInterface;
  */
 class Telegram
 {
+    /**
+     * parse_mode = Markdown
+     */
+    public const MARKDOWN_PARSE_MODE = 'Markdown';
+
+    /**
+     * parse_mode = HTML
+     */
+    public const HTML_PARSE_MODE = 'HTML';
+
     /** @var HttpClient HTTP Client */
     protected $http;
 

--- a/src/TelegramFile.php
+++ b/src/TelegramFile.php
@@ -20,12 +20,24 @@ class TelegramFile implements JsonSerializable
     public function __construct(string $content = '')
     {
         $this->content($content);
-        $this->payload['parse_mode'] = 'Markdown';
+        $this->payload['parse_mode'] = Telegram::MARKDOWN_PARSE_MODE;
     }
 
     public static function create(string $content = ''): self
     {
         return new self($content);
+    }
+
+    /**
+     * Notification simple message (Without Markdown support).
+     *
+     * @param string $content
+     *
+     * @return $this
+     */
+    public function text(string $content): self
+    {
+        return $this->content($content)->htmlParseMode();
     }
 
     /**
@@ -156,6 +168,22 @@ class TelegramFile implements JsonSerializable
     public function videoNote(string $file): self
     {
         return $this->file($file, 'video_note');
+    }
+
+    /**
+     * Attach a view file as the content for the notification.
+     * Supports Laravel blade template.
+     * Only html, without Markdown.
+     *
+     * @param string $view
+     * @param array  $data
+     * @param array  $mergeData
+     *
+     * @return $this
+     */
+    public function viewHtml(string $view, array $data = [], array $mergeData = []): self
+    {
+        return $this->view($view, $data, $mergeData)->htmlParseMode();
     }
 
     /**

--- a/src/TelegramMessage.php
+++ b/src/TelegramMessage.php
@@ -19,12 +19,25 @@ class TelegramMessage implements JsonSerializable
     public function __construct(string $content = '')
     {
         $this->content($content);
-        $this->payload['parse_mode'] = 'Markdown';
+        $this->payload['parse_mode'] = Telegram::MARKDOWN_PARSE_MODE;
     }
 
     public static function create(string $content = ''): self
     {
         return new self($content);
+    }
+
+    /**
+     * Notification simple message (Without Markdown support).
+     *
+     * @param string   $content
+     * @param int|null $limit
+     *
+     * @return $this
+     */
+    public function text(string $content, int $limit = null): self
+    {
+        return $this->content($content, $limit)->htmlParseMode();
     }
 
     /**
@@ -41,6 +54,22 @@ class TelegramMessage implements JsonSerializable
         }
 
         return $this;
+    }
+
+    /**
+     * Attach a view file as the content for the notification.
+     * Supports Laravel blade template.
+     * Only html, without Markdown.
+     *
+     * @param string $view
+     * @param array  $data
+     * @param array  $mergeData
+     *
+     * @return $this
+     */
+    public function viewHtml(string $view, array $data = [], array $mergeData = []): self
+    {
+        return $this->view($view, $data, $mergeData)->htmlParseMode();
     }
 
     /**

--- a/src/Traits/HasSharedLogic.php
+++ b/src/Traits/HasSharedLogic.php
@@ -3,6 +3,7 @@
 namespace NotificationChannels\Telegram\Traits;
 
 use Illuminate\Support\Traits\Conditionable;
+use NotificationChannels\Telegram\Telegram;
 
 /**
  * Trait HasSharedLogic.
@@ -19,6 +20,17 @@ trait HasSharedLogic
 
     /** @var array Inline Keyboard Buttons. */
     protected $buttons = [];
+
+    /**
+     * Set parse_mode = HTML.
+     *
+     * @return $this
+     */
+    public function htmlParseMode(): self
+    {
+        $this->payload['parse_mode'] = Telegram::HTML_PARSE_MODE;
+        return $this;
+    }
 
     /**
      * Recipient's Chat ID.

--- a/tests/TelegramMessageTest.php
+++ b/tests/TelegramMessageTest.php
@@ -21,10 +21,27 @@ class TelegramMessageTest extends TestCase
     }
 
     /** @test */
+    public function itAcceptsHtmlWhenConstructed(): void
+    {
+        $message = new TelegramMessage('Laravel Notification Channels are awesome!');
+        $message->htmlParseMode();
+        $this->assertEquals('Laravel Notification Channels are awesome!', $message->getPayloadValue('text'));
+        $this->assertEquals('HTML', $message->getPayloadValue('parse_mode'));
+    }
+
+    /** @test */
     public function theDefaultParseModeIsMarkdown(): void
     {
         $message = new TelegramMessage();
         $this->assertEquals('Markdown', $message->getPayloadValue('parse_mode'));
+    }
+
+    /** @test */
+    public function theAddedParseModeIsHtml(): void
+    {
+        $message = new TelegramMessage();
+        $message->text('Laravel Notification Channels are awesome');
+        $this->assertEquals('HTML', $message->getPayloadValue('parse_mode'));
     }
 
     /** @test */
@@ -40,6 +57,14 @@ class TelegramMessageTest extends TestCase
     {
         $message = new TelegramMessage();
         $message->content('Laravel Notification Channels are awesome!');
+        $this->assertEquals('Laravel Notification Channels are awesome!', $message->getPayloadValue('text'));
+    }
+
+    /** @test */
+    public function theNotificationTextCanBeSet(): void
+    {
+        $message = new TelegramMessage();
+        $message->text('Laravel Notification Channels are awesome!');
         $this->assertEquals('Laravel Notification Channels are awesome!', $message->getPayloadValue('text'));
     }
 


### PR DESCRIPTION
Hello!

If you send this message
```php

return TelegramMessage::create()
            ->content("2*2=4");
}
```

or this
```php
return TelegramMessage::create()
            ->content("I like snake_case");
```

you will get an error

```
Telegram responded with an error `400 - Bad Request: can't parse entities: 
Can't find end of the entity starting at byte offset...
```

Why? Because this package does not support sending messages with `parse_mode = HTML`. But the [documentation](https://telegram-bot-sdk.readme.io/reference/sendmessage#formatting-options) says that there can be two options - Markdown style and HTML style.

And if `parse_mode = Markdown`, then non-closed tags will be perceived as an error.
He's waiting for `*BOLD*`, but gets `2*` ...
He's waiting for `_italic text_`, but gets `snake_case` ...

I decided to fix it. Suggestions in this commit.
I added tests, and I added description in README.
But English is not my native language, please check the description in the README ))