### PR TITLE
Add escapedLine() method to TelegramMessage

### DIFF
--- a/src/TelegramMessage.php
+++ b/src/TelegramMessage.php
@@ -51,6 +51,17 @@ class TelegramMessage extends TelegramBase implements TelegramSenderContract
         return $this;
     }
 
+    public function escapedLine(string $content): self
+    {
+        // code taken from public gist https://gist.github.com/vijinho/3d66fab3270fc377b8485387ce7e7455
+        $content = str_replace([
+            '\\', '-', '#', '*', '+', '`', '.', '[', ']', '(', ')', '!', '&', '<', '>', '_', '{', '}', ], [
+            '\\\\', '\-', '\#', '\*', '\+', '\`', '\.', '\[', '\]', '\(', '\)', '\!', '\&', '\<', '\>', '\_', '\{', '\}',
+          ], $content);
+
+        return $this->line($content);
+    }
+
     /**
      * Attach a view file as the content for the notification.
      * Supports Laravel blade template.

--- a/tests/Feature/TelegramMessageTest.php
+++ b/tests/Feature/TelegramMessageTest.php
@@ -31,7 +31,7 @@ it('can escape special markdown characters per line', function () {
         ->line('Telegram Notification Channel is fantastic :)');
 
 
-    expect($message->getPayloadValue('text'))->toEqual("Laravel Notification\_Channels are awesome!\nTelegram Notification Channel is fantastic :)\n");
+    expect($message->getPayloadValue('text'))->toEqual("Laravel Notification\_Channels are awesome\!\nTelegram Notification Channel is fantastic :)\n");
 });
 
 it('can attach a view as the content', function () {

--- a/tests/Feature/TelegramMessageTest.php
+++ b/tests/Feature/TelegramMessageTest.php
@@ -25,6 +25,15 @@ it('can add one message per line', function () {
     expect($message->getPayloadValue('text'))->toEqual("Laravel Notification Channels are awesome!\nTelegram Notification Channel is fantastic :)\n");
 });
 
+it('can escape special markdown characters per line', function () {
+    $message = TelegramMessage::create()
+        ->escapedLine('Laravel Notification_Channels are awesome!')
+        ->line('Telegram Notification Channel is fantastic :)');
+
+
+    expect($message->getPayloadValue('text'))->toEqual("Laravel Notification\_Channels are awesome!\nTelegram Notification Channel is fantastic :)\n");
+});
+
 it('can attach a view as the content', function () {
     View::addLocation(__DIR__.'/../TestSupport');
 


### PR DESCRIPTION
Often we pass variables in to the ->line() method, and those variables might contain characters that need to be escaped as Telegram tries to parse the line in markdown

The following example code below will result in a server exception

```php
$email = 'hello_world@google.com'; // _ need to be escaped. Often this is fetched from the database.
TelegramMessage::create()->line('Is your email correct? ' . $email)->send();
```

This PR adds a new method called escapedLine that escape those characters.

For more information see:

https://stackoverflow.com/questions/40626896/telegram-does-not-escape-some-markdown-characters

https://github.com/telegraf/telegraf/issues/1242