### PR TITLE
add ability to change default behaiveor

### DIFF
--- a/src/Telegram.php
+++ b/src/Telegram.php
@@ -23,7 +23,7 @@ class Telegram
     /** @var string Telegram Bot API Base URI */
     protected string $apiBaseUri;
 
-    public function __construct(string $token = null, HttpClient $httpClient = null, string $apiBaseUri = null)
+    public function __construct(?string $token = null, ?HttpClient $httpClient = null, ?string $apiBaseUri = null)
     {
         $this->token = $token;
         $this->http = $httpClient ?? new HttpClient();

--- a/src/TelegramFile.php
+++ b/src/TelegramFile.php
@@ -48,7 +48,7 @@ class TelegramFile extends TelegramBase implements TelegramSenderContract
      * @param  resource|StreamInterface|string  $file
      * @return $this
      */
-    public function file(mixed $file, string $type, string $filename = null): self
+    public function file(mixed $file, string $type, ?string $filename = null): self
     {
         $this->type = $type;
 
@@ -102,7 +102,7 @@ class TelegramFile extends TelegramBase implements TelegramSenderContract
      *
      * @return $this
      */
-    public function document(string $file, string $filename = null): self
+    public function document(string $file, ?string $filename = null): self
     {
         return $this->file($file, 'document', $filename);
     }

--- a/src/TelegramMessage.php
+++ b/src/TelegramMessage.php
@@ -20,7 +20,7 @@ class TelegramMessage extends TelegramBase implements TelegramSenderContract
     {
         parent::__construct();
         $this->content($content);
-        $this->payload['parse_mode'] = 'MarkdownV2';
+        $this->payload['parse_mode'] = 'Markdown';
     }
 
     public static function create(string $content = ''): self

--- a/src/TelegramMessage.php
+++ b/src/TelegramMessage.php
@@ -20,7 +20,7 @@ class TelegramMessage extends TelegramBase implements TelegramSenderContract
     {
         parent::__construct();
         $this->content($content);
-        $this->payload['parse_mode'] = 'Markdown';
+        $this->payload['parse_mode'] = 'MarkdownV2';
     }
 
     public static function create(string $content = ''): self

--- a/src/TelegramMessage.php
+++ b/src/TelegramMessage.php
@@ -33,7 +33,7 @@ class TelegramMessage extends TelegramBase implements TelegramSenderContract
      *
      * @return $this
      */
-    public function content(string $content, int $limit = null): self
+    public function content(string $content, ?int $limit = null): self
     {
         $this->payload['text'] = $content;
 

--- a/src/Traits/HasSharedLogic.php
+++ b/src/Traits/HasSharedLogic.php
@@ -67,12 +67,12 @@ trait HasSharedLogic
      *
      * @return static
      */
-    public function parseMode(string $mode = null)
+    public function parseMode(?string $mode = null)
     {
         if (isset($mode) and ! in_array($mode, $allowed = ['Markdown', 'HTML', 'MarkdownV2'])) {
             throw new InvalidArgumentException("Invalid aggregate type [$mode], allowed types: [".implode(', ', $allowed).'].');
         }
-        
+
         $this->payload['parse_mode'] = $mode;
 
         return $this;

--- a/src/Traits/HasSharedLogic.php
+++ b/src/Traits/HasSharedLogic.php
@@ -51,6 +51,18 @@ trait HasSharedLogic
     }
 
     /**
+     * Recipient's Chat ID.
+     *
+     * @return static
+     */
+    public function normal()
+    {
+        unset($this->payload['parse_mode']);
+
+        return $this;
+    }
+    
+    /**
      * Add a normal keyboard button.
      *
      * @return static

--- a/src/Traits/HasSharedLogic.php
+++ b/src/Traits/HasSharedLogic.php
@@ -51,7 +51,7 @@ trait HasSharedLogic
     }
 
     /**
-     * Recipient's Chat ID.
+     * unsets parse mode of the message.
      *
      * @return static
      */
@@ -62,6 +62,19 @@ trait HasSharedLogic
         return $this;
     }
 
+
+    /**
+     * Sets parse mode of the message.
+     *
+     * @return static
+     */
+    public function parseMode(string $mode = null)
+    {
+        $this->payload['parse_mode'] = $mode;
+
+        return $this;
+    }
+    
     /**
      * Add a normal keyboard button.
      *

--- a/src/Traits/HasSharedLogic.php
+++ b/src/Traits/HasSharedLogic.php
@@ -3,6 +3,7 @@
 namespace NotificationChannels\Telegram\Traits;
 
 use Illuminate\Support\Traits\Conditionable;
+use InvalidArgumentException;
 
 /**
  * Trait HasSharedLogic.

--- a/src/Traits/HasSharedLogic.php
+++ b/src/Traits/HasSharedLogic.php
@@ -61,7 +61,7 @@ trait HasSharedLogic
 
         return $this;
     }
-    
+
     /**
      * Add a normal keyboard button.
      *

--- a/src/Traits/HasSharedLogic.php
+++ b/src/Traits/HasSharedLogic.php
@@ -69,6 +69,10 @@ trait HasSharedLogic
      */
     public function parseMode(string $mode = null)
     {
+        if (isset($mode) and ! in_array($mode, $allowed = ['Markdown', 'HTML', 'MarkdownV2'])) {
+            throw new InvalidArgumentException("Invalid aggregate type [$mode], allowed types: [".implode(', ', $allowed).'].');
+        }
+        
         $this->payload['parse_mode'] = $mode;
 
         return $this;

--- a/src/Traits/HasSharedLogic.php
+++ b/src/Traits/HasSharedLogic.php
@@ -62,7 +62,6 @@ trait HasSharedLogic
         return $this;
     }
 
-
     /**
      * Sets parse mode of the message.
      *
@@ -74,7 +73,7 @@ trait HasSharedLogic
 
         return $this;
     }
-    
+
     /**
      * Add a normal keyboard button.
      *


### PR DESCRIPTION
in some cases when the message contains one of the markdown characters ( * or _ ) telegram will not send the message.
This PR will add a normal function so the developers can overwrite the parse mode behavior to send messages that contain markdown characters as a standard message.
also changed markdown to the new markdownV2 according to telegrams documentation.[link](https://core.telegram.org/bots/api#markdownv2-style) [link](https://core.telegram.org/bots/api#markdown-style)