### PR TITLE
Addition of 'lineIf' method to messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ class InvoicePaid extends Notification
             // Markdown supported.
             ->content("Hello there!")
             ->line("Your invoice has been *PAID*")
+            ->lineIf($notifiable->amount > 0, "Amount paid: {$notifiable->amount}")
             ->line("Thank you!")
 
             // (Optional) Blade template for the content.
@@ -395,6 +396,7 @@ For more information on supported parameters, check out these [docs](https://cor
 
 - `content(string $content, int $limit = null)`: Notification message, supports markdown. For more information on supported markdown styles, check out these [docs](https://core.telegram.org/bots/api#formatting-options).
 - `line(string $content)`: Adds a message in a new line.
+- `lineIf(bool $boolean, string $line)`: Adds a message in a new line if the given condition is true.
 - `escapedLine(string $content)`: Adds a message in a new line while escaping special characters (For Markdown).
 - `view(string $view, array $data = [], array $mergeData = [])`: (optional) Blade template name with Telegram supported HTML or Markdown syntax content if you wish to use a view file instead of the `content()` method.
 - `chunk(int $limit = 4096)`: (optional) Message chars chunk size to send in parts (For long messages). Note: Chunked messages will be rate limited to one message per second to comply with rate limitation requirements from Telegram.

--- a/src/TelegramMessage.php
+++ b/src/TelegramMessage.php
@@ -51,7 +51,7 @@ class TelegramMessage extends TelegramBase implements TelegramSenderContract
         return $this;
     }
 
-    public function lineIf($boolean, $line): self
+    public function lineIf(bool $boolean, string $line): self
     {
         if ($boolean) {
             return $this->line($line);

--- a/src/TelegramMessage.php
+++ b/src/TelegramMessage.php
@@ -51,6 +51,15 @@ class TelegramMessage extends TelegramBase implements TelegramSenderContract
         return $this;
     }
 
+    public function lineIf($boolean, $line): self
+    {
+        if ($boolean) {
+            return $this->line($line);
+        }
+
+        return $this;
+    }
+
     public function escapedLine(string $content): self
     {
         // code taken from public gist https://gist.github.com/vijinho/3d66fab3270fc377b8485387ce7e7455

--- a/tests/Feature/TelegramMessageTest.php
+++ b/tests/Feature/TelegramMessageTest.php
@@ -25,6 +25,14 @@ it('can add one message per line', function () {
     expect($message->getPayloadValue('text'))->toEqual("Laravel Notification Channels are awesome!\nTelegram Notification Channel is fantastic :)\n");
 });
 
+it('can add one message per lineIf if first argument is true', function () {
+    $message = TelegramMessage::create()
+        ->lineIf(true,'Laravel Notification Channels are awesome!')
+        ->lineIf(false,'Telegram Notification Channel is fantastic :)')
+        ->lineIf(true,'Telegram Notification Channel is fantastic =)');
+    expect($message->getPayloadValue('text'))->toEqual("Laravel Notification Channels are awesome!\nTelegram Notification Channel is fantastic =)\n");
+});
+
 it('can escape special markdown characters per line', function () {
     $message = TelegramMessage::create()
         ->escapedLine('Laravel Notification_Channels are awesome!')


### PR DESCRIPTION
This pull request introduces a new method called 'lineIf' to the codebase. 
The 'lineIf' method adds a line to the content if the first argument evaluates to true. This enhancement is inspired by a similar method found in Laravel's MailMessage class (https://laravel.com/api/10.x/Illuminate/Notifications/Messages/MailMessage.html#method_lineIf)

```php
 TelegramMessage::create()
            ->to($notifiable->telegram_user_id)
            ->lineIf($this->amount > 0, "Amount paid: {$this->amount}");
```