### PR TITLE
Call to a member function toNotGiven() on not TelegramSenderContract

### DIFF
--- a/src/TelegramChannel.php
+++ b/src/TelegramChannel.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Psr7\Response;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\Telegram\Contracts\TelegramSenderContract;
 use NotificationChannels\Telegram\Exceptions\CouldNotSendNotification;
 
 /**
@@ -36,6 +37,11 @@ class TelegramChannel
 
         if (is_string($message)) {
             $message = TelegramMessage::create($message);
+        }
+
+        if ($message instanceof TelegramSenderContract === false)
+        {
+            return null;
         }
 
         if ($message->toNotGiven()) {


### PR DESCRIPTION
This pull request allows us not to send notifications if we do not return TelegramSenderContract.

In some cases I no longer need to send a notification. The most common case is that the time for sending the notification has already expired. I would like to be able to return a type that does not implement the TelegramSenderContract functionality.
Look at the following code
```
public function toTelegram($notifiable): TelegramMessage|false
 {
        if (do not send notification)
        {
            return false;
        }

        // Send notification
        return TelegramMessage::create()
            ->to(config('services.telegram-bot-api.chat_id'))
            ->line('hello');
      
}
```
This code return error ``local.ERROR: Call to a member function toNotGiven() on false {"exception":"[object] (Error(code: 0): Call to a member function toNotGiven() on false at /var/www/html/vendor/laravel-notification-channels/telegram/src/TelegramChannel.php:41)``