### PR TITLE
Add TelegramMessage::escapeMarkdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ class InvoicePaid extends Notification
             ->content("Hello there!")
             ->line("Your invoice has been *PAID*")
             ->lineIf($notifiable->amount > 0, "Amount paid: {$notifiable->amount}")
-            ->line("Thank you!")
+            ->line(sprintf("Thank you, ".TelegramMessage::escapeMarkdown("$user->name!"))
 
             // (Optional) Blade template for the content.
             // ->view('notification', ['url' => $url])
@@ -524,6 +524,10 @@ For more information on supported parameters, check out these [docs](https://cor
 
 > [!NOTE]
 > Chunked messages will be rate limited to one message per second to comply with rate limitation requirements from Telegram.
+
+#### Helper Methods:
+
+- `escapeMarkdown(string $content)` - Escape a string to make it safe for the `markdownv2` parse mode
 
 ### Telegram Location Methods
 

--- a/src/TelegramMessage.php
+++ b/src/TelegramMessage.php
@@ -32,6 +32,16 @@ final class TelegramMessage extends TelegramBase implements TelegramSenderContra
         return new self($content);
     }
 
+    /** @see https://core.telegram.org/bots/api#markdownv2-style */
+    public static function escapeMarkdown(string $content): ?string
+    {
+        return preg_replace_callback(
+            '/[_*[\]()~`>#\+\-=|{}.!]/',
+            fn ($matches): string => "\\$matches[0]",
+            $content
+        );
+    }
+
     public function content(string $content, ?int $limit = null): self
     {
         $this->payload['text'] = $content;
@@ -58,13 +68,9 @@ final class TelegramMessage extends TelegramBase implements TelegramSenderContra
     {
         $content = str_replace('\\', '\\\\', $content);
 
-        $escapedContent = preg_replace_callback(
-            '/[_*[\]()~`>#\+\-=|{}.!]/',
-            fn ($matches): string => "\\$matches[0]",
-            $content
-        );
+        $escapedContent = self::escapeMarkdown($content) ?: $content;
 
-        return $this->line($escapedContent ?? $content);
+        return $this->line($escapedContent);
     }
 
     public function view(string $view, array $data = [], array $mergeData = []): self

--- a/tests/Feature/TelegramMessageTest.php
+++ b/tests/Feature/TelegramMessageTest.php
@@ -41,6 +41,27 @@ it('can escape special markdown characters per line', function () {
     expect($message->getPayloadValue('text'))->toEqual("Laravel Notification\_Channels are awesome\!\nTelegram Notification Channel is fantastic :)\n");
 });
 
+it('can escape markdown characters', function (string $input, string $expected) {
+    expect(TelegramMessage::escapeMarkdown($input))->toEqual($expected);
+})->with([
+    'special characters' => ['_*[]()~`>#+-=|{}.!', '\_\*\[\]\(\)\~\`\>\#\+\-\=\|\{\}\.\!'],
+    'a string with special characters' => ['Hello, _world_!', 'Hello, \_world\_\!'],
+    'a string with *' => ['*Hello, world!*', '\*Hello, world\!\*'],
+    'a string with []' => ['[Hello, world!]', '\[Hello, world\!\]'],
+    'a string with ()' => ['(Hello, world!)', '\(Hello, world\!\)'],
+    'a string with ~' => ['~Hello, world!~', '\~Hello, world\!\~'],
+    'a string with `' => ['`Hello, world!`', '\`Hello, world\!\`'],
+    'a string with >' => ['>Hello, world!', '\>Hello, world\!'],
+    'a string with #' => ['#Hello, world!', '\#Hello, world\!'],
+    'a string with +' => ['+Hello, world!', '\+Hello, world\!'],
+    'a string with -' => ['-Hello, world!', '\-Hello, world\!'],
+    'a string with =' => ['=Hello, world!', '\=Hello, world\!'],
+    'a string with |' => ['|Hello, world!', '\|Hello, world\!'],
+    'a string with {}' => ['{Hello, world!}', '\{Hello, world\!\}'],
+    'a string with .' => ['.Hello, world!', '\.Hello, world\!'],
+    'a string with !' => ['!Hello, world!', '\!Hello, world\!'],
+]);
+
 it('can attach a view as the content', function () {
     View::addLocation(__DIR__.'/../TestSupport');
 


### PR DESCRIPTION
Sometimes we need to escape a part of a line, so `TelegramMessage::escapedLine` is not really suitable as it escapes the whole line.

example

```php
$message = TelegramMessage::create()
    ->parseMode(\NotificationChannels\Telegram\Enums\ParseMode::MarkdownV2)
    ->escapedLine("A new user!")
    ->line("*email*: ".TelegramMessage::escapeMarkdown($user->email));
```

The escaping pattern is the same (untouched).