### PR TITLE
Add button style support (danger, success, primary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `telegram` will be documented in this file
 
+## Unreleased
+
+### Added
+
+- Optional `style` parameter (`'danger'`, `'success'`, `'primary'`) on `button()`, `buttonWithCallback()`, and `buttonWithWebApp()` methods for colored inline keyboard buttons (Telegram Bot API 9.4).
+
 ## 7.0 - 2026-03-19
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ class InvoicePaid extends Notification
         // ->sendWhen($notifiable->amount > 0)
         // ->buttonWithWebApp('Open Web App', $url)
         // ->buttonWithCallback('Confirm', 'confirm_invoice '.$this->invoice->id)
+        // ->buttonWithCallback('Delete', 'delete', style: 'danger')
+        // ->buttonWithCallback('Approve', 'approve', style: 'success')
     }
 }
 ```
@@ -717,9 +719,9 @@ For more information on supported parameters, check out these [docs](https://cor
 - `token(string $token)` - Override default bot token.
 - `parseMode(enum ParseMode $mode)` - Set message parse mode (or `normal()` to unset). Default is `ParseMode::Markdown`.
 - `keyboard(string $text, int $columns = 2, bool $requestContact = false, bool $requestLocation = false)` - Add regular keyboard. You can add as many as you want, and they'll be placed 2 in a row by default.
-- `button(string $text, string $url, int $columns = 2)` - Add inline CTA button.
-- `buttonWithCallback(string $text, string $callbackData, int $columns = 2)` - Add inline button with callback.
-- `buttonWithWebApp(string $text, string $url, int $columns = 2)` - Add inline web app button.
+- `button(string $text, string $url, int $columns = 2, ?string $style = null)` - Add inline CTA button. Optional `style`: `'danger'` (red), `'success'` (green), `'primary'` (blue).
+- `buttonWithCallback(string $text, string $callbackData, int $columns = 2, ?string $style = null)` - Add inline button with callback.
+- `buttonWithWebApp(string $text, string $url, int $columns = 2, ?string $style = null)` - Add inline web app button.
 - `disableNotification(bool $disableNotification = true)` - Send silently (notification without sound).
 - `businessConnectionId(string $businessConnectionId)` - Send on behalf of a connected business account.
 - `messageThreadId(int $messageThreadId)` - Send to a forum / topic thread.

--- a/src/Traits/HasSharedLogic.php
+++ b/src/Traits/HasSharedLogic.php
@@ -126,15 +126,22 @@ trait HasSharedLogic
      * @param  string  $text  The text to display on the button
      * @param  string  $url  The URL to open when button is pressed
      * @param  int  $columns  Number of columns for button layout
+     * @param  ?string  $style  Button style: 'danger' (red), 'success' (green), 'primary' (blue)
      *
      * @throws JsonException When JSON encoding fails
      */
-    public function button(string $text, string $url, int $columns = 2): static
+    public function button(string $text, string $url, int $columns = 2, ?string $style = null): static
     {
-        $this->buttons[] = [
+        $button = [
             'text' => $text,
             'url' => $url,
         ];
+
+        if ($style !== null) {
+            $button['style'] = $style;
+        }
+
+        $this->buttons[] = $button;
 
         return $this->updateInlineKeyboard($columns);
     }
@@ -145,15 +152,22 @@ trait HasSharedLogic
      * @param  string  $text  The text to display on the button
      * @param  string  $callbackData  The data to send when button is pressed
      * @param  int  $columns  Number of columns for button layout
+     * @param  ?string  $style  Button style: 'danger' (red), 'success' (green), 'primary' (blue)
      *
      * @throws JsonException When JSON encoding fails
      */
-    public function buttonWithCallback(string $text, string $callbackData, int $columns = 2): static
+    public function buttonWithCallback(string $text, string $callbackData, int $columns = 2, ?string $style = null): static
     {
-        $this->buttons[] = [
+        $button = [
             'text' => $text,
             'callback_data' => $callbackData,
         ];
+
+        if ($style !== null) {
+            $button['style'] = $style;
+        }
+
+        $this->buttons[] = $button;
 
         return $this->updateInlineKeyboard($columns);
     }
@@ -164,15 +178,22 @@ trait HasSharedLogic
      * @param  string  $text  The text to display on the button
      * @param  string  $url  The URL of the Web App to open
      * @param  int  $columns  Number of columns for button layout
+     * @param  ?string  $style  Button style: 'danger' (red), 'success' (green), 'primary' (blue)
      *
      * @throws JsonException When JSON encoding fails
      */
-    public function buttonWithWebApp(string $text, string $url, int $columns = 2): static
+    public function buttonWithWebApp(string $text, string $url, int $columns = 2, ?string $style = null): static
     {
-        $this->buttons[] = [
+        $button = [
             'text' => $text,
             'web_app' => ['url' => $url],
         ];
+
+        if ($style !== null) {
+            $button['style'] = $style;
+        }
+
+        $this->buttons[] = $button;
 
         return $this->updateInlineKeyboard($columns);
     }

--- a/tests/Feature/TelegramMessageTest.php
+++ b/tests/Feature/TelegramMessageTest.php
@@ -238,6 +238,26 @@ it('can set common telegram send options', function () {
     ]);
 });
 
+test('an inline button with style can be added to the message', function () {
+    $message = TelegramMessage::create()->button('Delete', 'https://example.com', style: 'danger');
+    expect($message->getPayloadValue('reply_markup'))->toEqual('{"inline_keyboard":[[{"text":"Delete","url":"https:\/\/example.com","style":"danger"}]]}');
+});
+
+test('an inline button with callback and style can be added to the message', function () {
+    $message = TelegramMessage::create()->buttonWithCallback('Confirm', 'confirm_action', style: 'success');
+    expect($message->getPayloadValue('reply_markup'))->toEqual('{"inline_keyboard":[[{"text":"Confirm","callback_data":"confirm_action","style":"success"}]]}');
+});
+
+test('an inline button with primary style can be added to the message', function () {
+    $message = TelegramMessage::create()->buttonWithCallback('Info', 'info_action', style: 'primary');
+    expect($message->getPayloadValue('reply_markup'))->toEqual('{"inline_keyboard":[[{"text":"Info","callback_data":"info_action","style":"primary"}]]}');
+});
+
+test('an inline button without style has no style field', function () {
+    $message = TelegramMessage::create()->button('Laravel', 'https://laravel.com');
+    expect($message->getPayloadValue('reply_markup'))->toEqual('{"inline_keyboard":[[{"text":"Laravel","url":"https:\/\/laravel.com"}]]}');
+});
+
 it('returns chunked telegram responses as decoded arrays', function () {
     $message = TelegramMessage::create(str_repeat('A', 12))->chunk(5);
 


### PR DESCRIPTION

  ## Summary
                                                                                                                                                                                          
  Telegram Bot API 9.4 introduced the optional `style` field for `InlineKeyboardButton`, allowing buttons to be colored:                                                                  
  - `'danger'` — red                                                                                                                                                                      
  - `'success'` — green                                                                                                                                                                   
  - `'primary'` — blue                                                                                                                                                                    
   
  This PR adds an optional `?string $style` parameter to `button()`, `buttonWithCallback()`, and `buttonWithWebApp()` methods. Fully backward-compatible — when `style` is not passed, the
   button behaves as before.                                                                                                                                                            
                                                                                                                                                                                          
  ### Usage                                                                                                                                                                             

  ```php
  TelegramMessage::create()
      ->content('Are you sure?')
      ->buttonWithCallback('Confirm', 'confirm:123', style: 'success')
      ->buttonWithCallback('Delete', 'delete:123', style: 'danger');                                                                                                                      
```                                                                                                                                                                                                                                                                                                
### Result
<img width="488" height="77" alt="Screenshot at Apr 10 20-13-25" src="https://github.com/user-attachments/assets/a8ff0497-93f1-4f21-8a15-31b6a8945c04" />


### References                                                                                                                                                                                                                                                                                                                               
  - https://core.telegram.org/bots/api-changelog                                                                                                                                          
  - https://core.telegram.org/bots/api#inlinekeyboardbutton
                                                                                                                                                                                          